### PR TITLE
Add basic normalize tests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,7 +9,7 @@ License: MIT + file LICENSE
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.1
-Imports: 
+Imports:
     base64enc,
     knitr,
     rmarkdown,
@@ -18,4 +18,7 @@ Imports:
     uuid,
     xml2,
     yaml
+Suggests:
+    testthat (>= 3.0.0)
+Config/testthat/edition: 3
 VignetteBuilder: knitr

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,4 @@
+library(testthat)
+library(r2bb)
+
+test_check("r2bb")

--- a/tests/testthat/test-normalize-question.R
+++ b/tests/testthat/test-normalize-question.R
@@ -1,0 +1,17 @@
+test_that("normalize_question works", {
+  q <- normalize_question(list(
+    title = "Capital of France",
+    question_type = "multiple_choice",
+    question_text = "What is the capital of France?",
+    feedback = "Paris is the capital of France.",
+    random_order = FALSE,
+    answers = list(
+      list(text = "Paris", correct = TRUE),
+      list(text = "London", correct = FALSE),
+      list(text = "Berlin", correct = FALSE),
+      list(text = "Madrid", correct = FALSE)
+    )
+  ))
+  expect_equal(q$title, "Capital of France")
+  expect_s3_class(q, "r2bb_question")
+})

--- a/tests/testthat/test-normalize-test.R
+++ b/tests/testthat/test-normalize-test.R
@@ -1,0 +1,25 @@
+test_that("normalize_test works", {
+  q <- normalize_question(list(
+    title = "Capital of France",
+    question_type = "multiple_choice",
+    question_text = "What is the capital of France?",
+    feedback = "Paris is the capital of France.",
+    random_order = FALSE,
+    answers = list(
+      list(text = "Paris", correct = TRUE),
+      list(text = "London", correct = FALSE),
+      list(text = "Berlin", correct = FALSE),
+      list(text = "Madrid", correct = FALSE)
+    )
+  ))
+  t <- normalize_test(list(
+    title = "Capitals Test",
+    description = "Test about country capitals.",
+    instructions = "Answer the questions.",
+    contents = list(
+      list(type = "question", points = 1, question = q)
+    )
+  ))
+  expect_equal(t$title, "Capitals Test")
+  expect_s3_class(t, "r2bb_test")
+})


### PR DESCRIPTION
## Summary
- add tests/testthat scaffolding
- add simple tests for `normalize_question` and `normalize_test`
- include testthat in DESCRIPTION and configure edition
- split question and test checks into separate files

## Testing
- `Rscript -e "devtools::test()"`

------
https://chatgpt.com/codex/tasks/task_e_6840f612cb488326970f1e8f21db4115