### PR TITLE
Add tests for all question types

### DIFF
--- a/tests/testthat/test-normalize-question.R
+++ b/tests/testthat/test-normalize-question.R
@@ -1,17 +1,94 @@
-test_that("normalize_question works", {
-  q <- normalize_question(list(
-    title = "Capital of France",
+
+test_that("normalize_question works for all supported types", {
+  # multiple_choice
+  q_mc <- normalize_question(list(
+    title = "MC",
     question_type = "multiple_choice",
-    question_text = "What is the capital of France?",
-    feedback = "Paris is the capital of France.",
-    random_order = FALSE,
+    question_text = "Choose one",
     answers = list(
-      list(text = "Paris", correct = TRUE),
-      list(text = "London", correct = FALSE),
-      list(text = "Berlin", correct = FALSE),
-      list(text = "Madrid", correct = FALSE)
+      list(text = "A", correct = TRUE),
+      list(text = "B", correct = FALSE)
     )
   ))
-  expect_equal(q$title, "Capital of France")
-  expect_s3_class(q, "r2bb_question")
+  expect_s3_class(q_mc, "r2bb_question_multiple_choice")
+
+  # multiple_answer
+  q_ma <- normalize_question(list(
+    title = "MA",
+    question_type = "multiple_answer",
+    question_text = "Select all",
+    answers = list(
+      list(text = "A", correct = TRUE),
+      list(text = "B", correct = TRUE),
+      list(text = "C", correct = FALSE)
+    )
+  ))
+  expect_s3_class(q_ma, "r2bb_question_multiple_answer")
+
+  # single_blank
+  q_sb <- normalize_question(list(
+    title = "SB",
+    question_type = "single_blank",
+    question_text = "Fill in",
+    answers = list("answer")
+  ))
+  expect_s3_class(q_sb, "r2bb_question_single_blank")
+
+  # multiple_blanks
+  q_mb <- normalize_question(list(
+    title = "MB",
+    question_type = "multiple_blanks",
+    question_text = "[A] and [B]",
+    answers = list(A = list("a"), B = list("b"))
+  ))
+  expect_s3_class(q_mb, "r2bb_question_multiple_blanks")
+
+  # numeric
+  q_num <- normalize_question(list(
+    title = "NUM",
+    question_type = "numeric",
+    question_text = "2+2",
+    answer = 4
+  ))
+  expect_s3_class(q_num, "r2bb_question_numeric")
+
+  # file_upload
+  q_fu <- normalize_question(list(
+    title = "FU",
+    question_type = "file_upload",
+    question_text = "Upload"
+  ))
+  expect_s3_class(q_fu, "r2bb_question_file_upload")
+
+  # short_answer
+  q_sa <- normalize_question(list(
+    title = "SA",
+    question_type = "short_answer",
+    question_text = "Explain",
+    answer = "Because"
+  ))
+  expect_s3_class(q_sa, "r2bb_question_short_answer")
+
+  # matching
+  q_match <- normalize_question(list(
+    title = "MATCH",
+    question_type = "matching",
+    question_text = "Match",
+    questions = list(list(text = "1", answer_index = 1)),
+    answers = list("one")
+  ))
+  expect_s3_class(q_match, "r2bb_question_matching")
 })
+
+
+test_that("normalize_question errors on unknown type", {
+  expect_error(
+    normalize_question(list(
+      title = "Bad",
+      question_type = "unknown_type",
+      question_text = "?"
+    )),
+    "Unknown question type"
+  )
+})
+

--- a/tests/testthat/test-normalize-test.R
+++ b/tests/testthat/test-normalize-test.R
@@ -1,25 +1,77 @@
-test_that("normalize_test works", {
-  q <- normalize_question(list(
-    title = "Capital of France",
+
+test_that("normalize_test works with all question types", {
+  q_mc <- normalize_question(list(
+    title = "MC",
     question_type = "multiple_choice",
-    question_text = "What is the capital of France?",
-    feedback = "Paris is the capital of France.",
-    random_order = FALSE,
+    question_text = "Choose one",
     answers = list(
-      list(text = "Paris", correct = TRUE),
-      list(text = "London", correct = FALSE),
-      list(text = "Berlin", correct = FALSE),
-      list(text = "Madrid", correct = FALSE)
+      list(text = "A", correct = TRUE),
+      list(text = "B", correct = FALSE)
     )
   ))
+  q_ma <- normalize_question(list(
+    title = "MA",
+    question_type = "multiple_answer",
+    question_text = "Select all",
+    answers = list(
+      list(text = "A", correct = TRUE),
+      list(text = "B", correct = TRUE),
+      list(text = "C", correct = FALSE)
+    )
+  ))
+  q_sb <- normalize_question(list(
+    title = "SB",
+    question_type = "single_blank",
+    question_text = "Fill in",
+    answers = list("answer")
+  ))
+  q_mb <- normalize_question(list(
+    title = "MB",
+    question_type = "multiple_blanks",
+    question_text = "[A] and [B]",
+    answers = list(A = list("a"), B = list("b"))
+  ))
+  q_num <- normalize_question(list(
+    title = "NUM",
+    question_type = "numeric",
+    question_text = "2+2",
+    answer = 4
+  ))
+  q_fu <- normalize_question(list(
+    title = "FU",
+    question_type = "file_upload",
+    question_text = "Upload"
+  ))
+  q_sa <- normalize_question(list(
+    title = "SA",
+    question_type = "short_answer",
+    question_text = "Explain",
+    answer = "Because"
+  ))
+  q_match <- normalize_question(list(
+    title = "MATCH",
+    question_type = "matching",
+    question_text = "Match",
+    questions = list(list(text = "1", answer_index = 1)),
+    answers = list("one")
+  ))
+
   t <- normalize_test(list(
-    title = "Capitals Test",
-    description = "Test about country capitals.",
-    instructions = "Answer the questions.",
+    title = "All Qs",
+    description = "desc",
+    instructions = "inst",
     contents = list(
-      list(type = "question", points = 1, question = q)
+      list(type = "question", points = 1, question = q_mc),
+      list(type = "question", points = 1, question = q_ma),
+      list(type = "question", points = 1, question = q_sb),
+      list(type = "question", points = 1, question = q_mb),
+      list(type = "question", points = 1, question = q_num),
+      list(type = "question", points = 1, question = q_fu),
+      list(type = "question", points = 1, question = q_sa),
+      list(type = "question", points = 1, question = q_match)
     )
   ))
-  expect_equal(t$title, "Capitals Test")
   expect_s3_class(t, "r2bb_test")
+  expect_length(t$contents, 8)
 })
+


### PR DESCRIPTION
## Summary
- expand unit tests to cover every supported question type
- check that unknown question types trigger an error

## Testing
- `devtools::test()`

------
https://chatgpt.com/codex/tasks/task_e_6840fabd64548326aaa119b799f0eb3e