### PR TITLE
Add RYaml vignette link

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,8 @@ to_bbxml_package(test, "midterm-exam.zip")
 
 - [Basic Usage Vignette](https://mbertolacci.github.io/r2bb/articles/basic-usage.html) - Comprehensive usage guide
 - [Question Types Vignette](https://mbertolacci.github.io/r2bb/articles/question-types.html) - Examples of all question types
-- [Example Files](r2bb/inst/examples/) - Sample YAML and RYaml files
+- [RYaml Vignette](https://mbertolacci.github.io/r2bb/articles/ryaml.html) - Use RYaml for dynamic questions
+- [Example Files](https://github.com/mbertolacci/r2bb/tree/main/inst/examples) - Sample YAML and RYaml files
 
 ## Workflow
 


### PR DESCRIPTION
## Summary
- add link to the RYaml vignette in the Documentation section of the README
- update Example Files link to an absolute URL so it works on GitHub Pages

## Testing
- `devtools::test()`

------
https://chatgpt.com/codex/tasks/task_e_6843be9aa6248326bc9ca64d3af30e9f