### PR TITLE
Fix README nested code block

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ print(q)
 
 Create questions with embedded R code for computed answers:
 
-```yaml
+````yaml
 # t-test.Ryaml
 ```{r, echo = FALSE}
 x <- c(1, 5, 3, 4, 2)
@@ -87,7 +87,7 @@ answers:
     correct: true
   - text: "1.23"
     correct: false
-```
+````
 
 ```r
 # Render RYaml to YAML, then load and print


### PR DESCRIPTION
## Summary
- fix nested code block in README by using four backticks

## Testing
- `R -q -e "devtools::check(document = FALSE, quiet = TRUE)"` *(fails: R CMD check found WARNINGs)*

------
https://chatgpt.com/codex/tasks/task_e_68450836ce448326bfa7b107d1ee98f1