### PR TITLE
Fix README test example

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,12 +116,24 @@ class(pool) <- "r2bb_pool"
 to_bbxml_package(pool, "stats-pool.zip")
 
 # Create a test with the pool
-test <- list(
+test <- normalize_test(list(
   title = "Midterm Exam",
-  pools = list(pool),
-  questions = list(read_question("bonus-question.yaml"))
-)
-class(test) <- "r2bb_test"
+  description = "A short midterm exam.",
+  instructions = "Answer all questions.",
+  contents = list(
+    list(
+      type = "random_block",
+      pool = pool,
+      questions_to_display = 1,
+      points_per_question = 4
+    ),
+    list(
+      type = "question",
+      points = 1,
+      question = read_question("bonus-question.yaml")
+    )
+  )
+))
 
 # Export test
 to_bbxml_package(test, "midterm-exam.zip")


### PR DESCRIPTION
## Summary
- update README test creation example to match basic usage vignette

## Testing
- `devtools::test()`

------
https://chatgpt.com/codex/tasks/task_e_6845aa64a708832690915d42bd80a36d